### PR TITLE
Fix for issue #3 / enhancements on child node processing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "svgViewer",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "A svg viewer allowing viewing svg files, as well as interacting with them dynamically.",
     "thingworxServer": "http://10.128.49.124:8036",
     "thingworxUser": "Administrator",

--- a/src/svgRenderer/svgRenderer.ts
+++ b/src/svgRenderer/svgRenderer.ts
@@ -274,20 +274,24 @@ export class SvgElement {
             // find the elements to override
             let elements = this.svgElement.querySelectorAll(`[${this.options.idField}="${override[this.options.overrideIdField]}"]`);
             // iterate over them
+
             for (const element of elements) {
                 if (this.options.applyToChildren) {
                     // apply the overrides to the children
-                    for (const child of element.children) {
-                        this.applyOverrideToElement(child, override);
-                    }
+                    this.applyOverrideToChildren(element, override);
                 } else {
                     this.applyOverrideToElement(element, override);
                 }
-                if(override["selectable"] !== false) {
-                    this.applyClickableToElement(element);
-                }
+
             }
         }
+    }
+
+    private applyOverrideToChildren(element: Element, override: SvgOverride) {
+        for (const child of element.children) {
+            this.applyOverrideToChildren(child, override);
+        }
+        this.applyOverrideToElement(element, override);
     }
 
     private applyClickableToElement(element: Element) {
@@ -307,6 +311,9 @@ export class SvgElement {
         // make sure we are not adding the same element twice
         if(this.previousOverrideElements.filter((el)=> (el.element == element)).length == 0) {
             this.previousOverrideElements.push({ element: element, cachedStyle: element.getAttribute("style"), cachedClass: element.getAttribute("class") });
+        }
+        if(override["selectable"] !== false) {
+            this.applyClickableToElement(element);
         }
         // iterate over the attributes to override
         for (const attrOverride in override) {


### PR DESCRIPTION
- Make apply to children recursive not just for first level of children.
- Fix overrides not being applied to selected element if apply to children selected.
- Fix clickable being applied to children when parent set to not clickable.
- Version bump to 1.1.1